### PR TITLE
Fix unsupported operand error while copying res dictionary

### DIFF
--- a/ckanext/cloudstorage/plugin/__init__.py
+++ b/ckanext/cloudstorage/plugin/__init__.py
@@ -107,7 +107,8 @@ class CloudStoragePlugin(MixinPlugin, plugins.SingletonPlugin):
         # we don't want to change original item from resources, just in case
         # someone will use it in another `before_delete`. So, let's copy it
         # and add `clear_upload` flag
-        res_dict = dict(res.items() + [('clear_upload', True)])
+        res_dict = res.copy()
+        res_dict.update([('clear_upload', True)])
 
         uploader = self.get_resource_uploader(res_dict)
 


### PR DESCRIPTION
I see the following error when I try to delete a resource that has an uploaded file in it.

```python
ERROR [ckan.config.middleware.flask_app] unsupported operand type(s) for +: 'dict_items' and 'list'
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.9/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/lib/python3.9/site-packages/flask/views.py", line 84, in view
    return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/flask/views.py", line 158, in dispatch_request
    return current_app.ensure_sync(meth)(*args, **kwargs)
  File "/srv/app/src/ckan/ckan/config/middleware/../../views/resource.py", line 467, in post
    get_action(u'resource_delete')(context, {u'id': resource_id})
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 504, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/action/delete.py", line 195, in resource_delete
    plugin.before_delete(context, data_dict,
  File "/srv/app/src/ckanext-cloudstorage/ckanext/cloudstorage/plugin/__init__.py", line 110, in before_delete
    res_dict = dict(res.items() + [('clear_upload', True)])
TypeError: unsupported operand type(s) for +: 'dict_items' and 'list'

```

In the code it was happening during the copying of the `res` dictionary to `res_dict` which I fixed by using the copy() method and updating the new dictionary.

Resource downloads work fine after the changes.